### PR TITLE
Make Movement to belong to Admin User

### DIFF
--- a/app/admin/incomes.rb
+++ b/app/admin/incomes.rb
@@ -26,6 +26,16 @@ ActiveAdmin.register Income do
     link_to "Duplicate", new_admin_income_path(income: income.duplicable_attributes)
   end
 
+  controller do
+    def create
+      build_resource
+
+      @income.admin_user = current_admin_user
+
+      create!
+    end
+  end
+
   index do
     selectable_column
 
@@ -52,6 +62,7 @@ ActiveAdmin.register Income do
       row :value
       row :drive_id
       row :transaction_hash
+      row :admin_user
       row :created_at
       row :updated_at
     end

--- a/app/admin/outgos.rb
+++ b/app/admin/outgos.rb
@@ -36,6 +36,8 @@ ActiveAdmin.register Outgo do
       ActiveRecord::Base.transaction do
         build_resource
 
+        @outgo.admin_user = current_admin_user
+
         Remapper.call(@outgo)
 
         if @outgo.valid?
@@ -116,6 +118,7 @@ ActiveAdmin.register Outgo do
       row :expected_movement
       row :drive_id
       row :transaction_hash
+      row :admin_user
       row :created_at
       row :updated_at
     end

--- a/app/models/movement.rb
+++ b/app/models/movement.rb
@@ -11,6 +11,7 @@ class Movement < ActiveRecord::Base
     allow_blank: true
 
   belongs_to :chargeable, polymorphic: true
+  belongs_to :admin_user
 
   delegate :inactive?, to: :chargeable, allow_nil: true, prefix: true
   delegate :currency, to: :chargeable, allow_nil: true

--- a/db/migrate/20210419004012_add_admin_user_to_movement.rb
+++ b/db/migrate/20210419004012_add_admin_user_to_movement.rb
@@ -1,0 +1,5 @@
+class AddAdminUserToMovement < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :movements, :admin_user
+  end
+end

--- a/spec/features/admin/incomes_spec.rb
+++ b/spec/features/admin/incomes_spec.rb
@@ -22,6 +22,7 @@ describe "Incomes" do
     expect(page).to have_content("Income#1")
     expect(page).to have_content("$100.00")
     expect(page).to have_content("ACCOUNT Account#1")
+    expect(page).to have_content("admin@example.com")
   end
 
   it "shows error message when user does not select chargeable" do

--- a/spec/features/admin/outgos_spec.rb
+++ b/spec/features/admin/outgos_spec.rb
@@ -63,6 +63,7 @@ describe "Outgos" do
     expect(page).to have_content("$100.00")
     expect(page).to have_content("$0.0")
     expect(page).to have_content("ACCOUNT/CARD Account#1")
+    expect(page).to have_content("admin@example.com")
   end
 
   context "when there is a mapping" do


### PR DESCRIPTION
[Closes #26]

- Add a relationship between Movement and AdminUser
- Assign current_user as user_admin_id whenever an outgo is created