### PR TITLE
Remove workaround for the validation of chargeable

### DIFF
--- a/app/admin/incomes.rb
+++ b/app/admin/incomes.rb
@@ -74,7 +74,6 @@ ActiveAdmin.register Income do
 
   form do |f|
     inputs t("active_admin.details", model: Income) do
-      semantic_errors :chargeable
       input :description, input_html: { autofocus: true }
       input :paid_to
       input :date, as: :string, input_html: { value: (f.object.date || Date.current) }

--- a/spec/features/admin/incomes_spec.rb
+++ b/spec/features/admin/incomes_spec.rb
@@ -27,20 +27,6 @@ describe "Incomes" do
     expect(page).to have_content("admin@example.com")
   end
 
-  it "shows error message when user does not select chargeable" do
-    click_on "Incomes"
-    click_on "New"
-
-    fill_in "Description", with: "Income#1"
-    expect(page).to have_field "Date", with: Date.current.to_s
-    fill_in "Date", with: "2017-12-31"
-    fill_in "Value", with: 100
-
-    click_on "Create"
-
-    expect(page).to have_content "Account can't be blank"
-  end
-
   context "when there is an income" do
     let!(:income) { create(:income) }
 


### PR DESCRIPTION
The validation is still working and now it is close to the field itself.

<img width="1450" alt="Screenshot 2022-12-30 at 11 12 50 AM" src="https://user-images.githubusercontent.com/53300/210090562-e5e8cc53-2925-4bb0-83d9-90b0c816afc1.png">
